### PR TITLE
Update node.js and fix unused argument warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
     default: 'all'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ inputs:
   url:
     description: 'Where to download the SDK from'
     required: true
-  cache-name:
-    description: 'cache key for the installed SDK'
-    required: true
   toolchains:
     description: 'comma separated list of toolchains to install.'
     required: false


### PR DESCRIPTION
Note: Strictly speaking this is a breaking change, since it removes an (albeit unused) parameter, so major version should probably be increased.

Fixes #3
Fixes #2 