### PR TITLE
Update Node Version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: 'all'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Bump node to v20 since GitHub is deprecating v16.